### PR TITLE
[JENKINS-43891] Use 2.X parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   </scm>
 
   <properties>
-    <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
+    <findbugs.failOnError>true</findbugs.failOnError>
     <jenkins.version>1.580.1</jenkins.version>
     <java.level>6</java.level>
   </properties>
@@ -151,25 +151,6 @@
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
-        <configuration>
-          <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
-          <failOnError>${maven.findbugs.failure.strict}</failOnError>
-          <xmlOutput>true</xmlOutput>
-          <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
   </scm>
 
   <properties>
-    <findbugs.failOnError>true</findbugs.failOnError>
     <jenkins.version>1.580.1</jenkins.version>
     <java.level>6</java.level>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>2.26</version>
   </parent>
 
   <artifactId>deployed-on-column</artifactId>
@@ -69,10 +69,9 @@
   </scm>
 
   <properties>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
+    <jenkins.version>1.580.1</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <dependencies>
@@ -96,6 +95,12 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
+      <version>2.13</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.3</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
@@ -103,6 +108,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.8.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+      <version>1.17</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -166,14 +177,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>  


### PR DESCRIPTION
[JENKINS-43891](https://issues.jenkins-ci.org/browse/JENKINS-43891)

- Use 2.X parent POM.
- Bump core version.
- Bump dependencies versions.

@reviewbybees @stephenc @jglick @kwhetstone @andresrc 