### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,5 +8,5 @@ buildPlugin(useContainerAgent: true,
                 // testing the Guava & Guice bumps
                 // https://github.com/jenkinsci/jenkins/pull/5707
                 // https://github.com/jenkinsci/jenkins/pull/5858
-                [ platform: "linux", jdk: "8", jenkins: '2.321', javaLevel: "8" ]
+                [ platform: "linux", jdk: "8", jenkins: '2.321' ]
         ])


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.

I'll expedite the merge, once the infrastructure changes on ci.jenkins.io are live, to prevent a failure on the master branch and new PRs.